### PR TITLE
Update python2.cygport

### DIFF
--- a/python2.cygport
+++ b/python2.cygport
@@ -93,7 +93,7 @@ python2_devel_CONTENTS="
 	usr/bin/pygettext.py
 	usr/bin/smtpd.py
 "
-python27_devel_REQUIRES="python${slot/.}-setuptools"
+python27_devel_REQUIRES="python${slot/.}-setuptools libcrypt-devel"
 # Unversioned components:
 #	usr/bin/python-config
 #	usr/lib/pkgconfig/python.pc


### PR DESCRIPTION
Python.h includes crypt.h from libcrypt-devel

Therefore this is requirement for Python.h to be at all useful

Not 100% if I'm doing this right but this should give the general idea.  Might want to check on the same for the Python 3 packages.